### PR TITLE
Improve logging settings and defaults

### DIFF
--- a/dashboard/backend/app/api.py
+++ b/dashboard/backend/app/api.py
@@ -1119,7 +1119,10 @@ async def update_moderation_settings(
         )
 
 
-@router.get("/guilds/{guild_id}/config/logging", response_model=schemas.LoggingSettings)
+@router.get(
+    "/guilds/{guild_id}/config/logging",
+    response_model=schemas.EventLoggingSettings,
+)
 async def get_logging_config(
     guild_id: int,
     db: Session = Depends(get_db),
@@ -1132,10 +1135,13 @@ async def get_logging_config(
         return await crud.get_logging_settings(db=db, guild_id=guild_id)
 
 
-@router.put("/guilds/{guild_id}/config/logging", response_model=schemas.LoggingSettings)
+@router.put(
+    "/guilds/{guild_id}/config/logging",
+    response_model=schemas.EventLoggingSettings,
+)
 async def update_logging_settings(
     guild_id: int,
-    settings_data: schemas.LoggingSettingsUpdate,
+    settings_data: schemas.EventLoggingSettingsUpdate,
     db: Session = Depends(get_db),
     has_admin: bool = Depends(has_admin_permissions),
 ):

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -114,6 +114,20 @@ class LoggingSettingsUpdate(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class EventLoggingSettings(BaseModel):
+    webhook_url: Optional[str] = None
+    enabled_events: Dict[str, bool] = Field(default_factory=dict)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class EventLoggingSettingsUpdate(BaseModel):
+    webhook_url: Optional[str] = None
+    enabled_events: Optional[Dict[str, bool]] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class ChannelExclusionSettings(BaseModel):
     excluded_channels: List[str] = Field(
         default_factory=list,

--- a/dashboard/backend/tests/test_api.py
+++ b/dashboard/backend/tests/test_api.py
@@ -238,11 +238,8 @@ def test_get_logging_settings(async_client: TestClient, monkeypatch):
 
     async def mock_get_logging_settings(db, guild_id):
         return {
-            "log_channel_id": "11111",
-            "message_delete_logging": True,
-            "message_edit_logging": True,
-            "member_join_logging": False,
-            "member_leave_logging": False,
+            "webhook_url": "https://example.com/webhook",
+            "enabled_events": {"message_delete": True},
         }
 
     monkeypatch.setattr(
@@ -253,8 +250,8 @@ def test_get_logging_settings(async_client: TestClient, monkeypatch):
     response = async_client.get("/api/guilds/123/config/logging")
     assert response.status_code == 200
     settings = response.json()
-    assert settings["log_channel_id"] == "11111"
-    assert settings["message_delete_logging"] is True
+    assert settings["webhook_url"] == "https://example.com/webhook"
+    assert settings["enabled_events"]["message_delete"] is True
 
 
 def test_update_logging_settings(async_client: TestClient, monkeypatch):
@@ -271,14 +268,14 @@ def test_update_logging_settings(async_client: TestClient, monkeypatch):
     )
 
     update_data = {
-        "log_channel_id": "22222",
-        "message_delete_logging": False,
+        "webhook_url": "https://example.com/new",
+        "enabled_events": {"message_delete": False},
     }
     response = async_client.put("/api/guilds/123/config/logging", json=update_data)
     assert response.status_code == 200
     settings = response.json()
-    assert settings["log_channel_id"] == "22222"
-    assert settings["message_delete_logging"] is False
+    assert settings["webhook_url"] == "https://example.com/new"
+    assert settings["enabled_events"]["message_delete"] is False
 
 
 def test_get_security_settings(async_client: TestClient, monkeypatch):

--- a/dashboard/frontend/src/components/ChannelManagement.jsx
+++ b/dashboard/frontend/src/components/ChannelManagement.jsx
@@ -157,7 +157,7 @@ const ChannelManagement = ({ guildId }) => {
               <DiscordSelector
                 guildId={guildId}
                 type="channels"
-                value={config.suggestions_channel}
+                value={config.suggestions_channel || ""}
                 onValueChange={(value) =>
                   handleInputChange("suggestions_channel", value)
                 }

--- a/dashboard/frontend/src/components/ModerationSettings.jsx
+++ b/dashboard/frontend/src/components/ModerationSettings.jsx
@@ -136,7 +136,7 @@ const ModerationSettings = ({ guildId }) => {
                   <DiscordSelector
                     guildId={guildId}
                     type="roles"
-                    value={config.suicidal_content_ping_role_id}
+                    value={config.suicidal_content_ping_role_id || ""}
                     onValueChange={(value) =>
                       handleInputChange("suicidal_content_ping_role_id", value)
                     }
@@ -148,7 +148,7 @@ const ModerationSettings = ({ guildId }) => {
                   <DiscordSelector
                     guildId={guildId}
                     type="roles"
-                    value={config.confirmation_ping_role_id}
+                    value={config.confirmation_ping_role_id || ""}
                     onValueChange={(value) =>
                       handleInputChange("confirmation_ping_role_id", value)
                     }

--- a/dashboard/frontend/src/components/RateLimitingSettings.jsx
+++ b/dashboard/frontend/src/components/RateLimitingSettings.jsx
@@ -223,7 +223,7 @@ const RateLimitingSettings = ({ guildId }) => {
             <div className="flex items-center space-x-2">
               <Switch
                 id="notifications_enabled"
-                checked={config.notifications_enabled || true}
+                checked={config.notifications_enabled ?? true}
                 onCheckedChange={(checked) =>
                   handleSwitchChange("notifications_enabled", checked)
                 }


### PR DESCRIPTION
## Summary
- add EventLoggingSettings schemas
- store logging webhook URLs and event toggles in the backend
- ensure dashboard forms prefill with defaults
- adjust tests for new logging config

## Testing
- `pytest`
- `pyright`
- `npm run test` in `dashboard/frontend`
- `npm run lint` in `dashboard/frontend`
- `npm run build` in `dashboard/frontend`
- `npm run build` in `website`

------
https://chatgpt.com/codex/tasks/task_e_687afa65f2dc832393b4db199f3959a1