### PR TITLE
Implement AI decision history

### DIFF
--- a/cogs/ai_channel_config_cog.py
+++ b/cogs/ai_channel_config_cog.py
@@ -15,6 +15,9 @@ from .aimod_helpers.config_manager import (
 )
 
 
+from .core_ai_cog import CoreAICog
+
+
 class AIChannelConfigCog(commands.Cog, name="AI Channel Config"):
     """
     Manages channel-specific AI moderation settings including exclusions and custom rules.
@@ -23,18 +26,16 @@ class AIChannelConfigCog(commands.Cog, name="AI Channel Config"):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
 
-    @commands.hybrid_group(
-        name="aichannel",
+    @CoreAICog.ai.group(
+        name="channel",
         description="Manage AI moderation settings for specific channels",
     )
-    async def aichannel(self, ctx: commands.Context):
+    async def channel(self, ctx: commands.Context):
         """AI channel configuration commands"""
         if ctx.invoked_subcommand is None:
             await ctx.send_help(ctx.command)
 
-    @aichannel.command(
-        name="exclude", description="Exclude a channel from AI moderation"
-    )
+    @channel.command(name="exclude", description="Exclude a channel from AI moderation")
     @app_commands.describe(
         channel="The channel to exclude from AI moderation (defaults to current channel)"
     )
@@ -64,7 +65,7 @@ class AIChannelConfigCog(commands.Cog, name="AI Channel Config"):
         else:
             await ctx.send(response)
 
-    @aichannel.command(
+    @channel.command(
         name="include",
         description="Include a channel in AI moderation (remove exclusion)",
     )
@@ -97,7 +98,7 @@ class AIChannelConfigCog(commands.Cog, name="AI Channel Config"):
         else:
             await ctx.send(response)
 
-    @aichannel.command(
+    @channel.command(
         name="listexcluded", description="List all channels excluded from AI moderation"
     )
     @app_commands.checks.has_permissions(administrator=True)
@@ -127,7 +128,7 @@ class AIChannelConfigCog(commands.Cog, name="AI Channel Config"):
         else:
             await ctx.send(response)
 
-    @aichannel.command(
+    @channel.command(
         name="setrules",
         description="Set custom AI moderation rules for a specific channel",
     )
@@ -170,7 +171,7 @@ class AIChannelConfigCog(commands.Cog, name="AI Channel Config"):
         else:
             await ctx.send(response)
 
-    @aichannel.command(
+    @channel.command(
         name="viewrules",
         description="View custom AI moderation rules for a specific channel",
     )
@@ -211,7 +212,7 @@ class AIChannelConfigCog(commands.Cog, name="AI Channel Config"):
         else:
             await ctx.send(response)
 
-    @aichannel.command(
+    @channel.command(
         name="listallrules",
         description="List all channels with custom AI moderation rules",
     )
@@ -250,7 +251,7 @@ class AIChannelConfigCog(commands.Cog, name="AI Channel Config"):
         else:
             await ctx.send(response)
 
-    @aichannel.command(
+    @channel.command(
         name="status", description="Check AI moderation status for a specific channel"
     )
     @app_commands.describe(

--- a/database/models.py
+++ b/database/models.py
@@ -155,6 +155,20 @@ class GuildAPIKey:
 
 
 @dataclass
+class AIDecision:
+    """AI moderation decision model."""
+
+    id: Optional[int] = None
+    guild_id: int = 0
+    message_id: int = 0
+    author_id: int = 0
+    author_name: Optional[str] = None
+    message_content_snippet: Optional[str] = None
+    decision: Dict[str, Any] | None = None
+    decision_timestamp: Optional[datetime] = None
+
+
+@dataclass
 class BlogPost:
     """Blog Post model."""
 
@@ -295,6 +309,18 @@ CREATE TABLE IF NOT EXISTS guild_api_keys (
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
+
+-- AI moderation decisions table
+CREATE TABLE IF NOT EXISTS ai_decisions (
+    id SERIAL PRIMARY KEY,
+    guild_id BIGINT NOT NULL,
+    message_id BIGINT NOT NULL,
+    author_id BIGINT NOT NULL,
+    author_name VARCHAR(255),
+    message_content_snippet TEXT,
+    decision JSONB,
+    decision_timestamp TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
 """
 
 # Index creation SQL
@@ -318,6 +344,7 @@ CREATE INDEX IF NOT EXISTS idx_guild_api_keys_guild_id ON guild_api_keys(guild_i
 CREATE INDEX IF NOT EXISTS idx_blog_posts_author_id ON blog_posts(author_id);
 CREATE INDEX IF NOT EXISTS idx_blog_posts_published ON blog_posts(published);
 CREATE INDEX IF NOT EXISTS idx_blog_posts_slug ON blog_posts(slug);
+CREATE INDEX IF NOT EXISTS idx_ai_decisions_guild_timestamp ON ai_decisions(guild_id, decision_timestamp);
 """
 
 # Trigger creation SQL for automatic updated_at timestamps


### PR DESCRIPTION
## Summary
- track AI decisions in Postgres with new table and dataclass
- build pagination UI for viewing decisions one by one
- expose command at `/ai last_decisions`
- nest all channel config commands under `/ai channel`

## Testing
- `npm run build` in `website`
- `npm run test` and `npm run lint` and `npm run build` in `dashboard/frontend`
- `pytest`
- `pyright`


------
https://chatgpt.com/codex/tasks/task_e_687b1e2e50408323a7e5013648faacd8