### PR TITLE
Fix last_decisions to filter by guild

### DIFF
--- a/cogs/core_ai_cog.py
+++ b/cogs/core_ai_cog.py
@@ -1316,10 +1316,12 @@ class CoreAICog(commands.Cog, name="Core AI"):
     @ai.command(
         name="last_decisions", description="View recent AI moderation decisions"
     )
+    @app_commands.guild_only()
     @app_commands.checks.has_permissions(administrator=True)
     async def ai_last_decisions(self, ctx: commands.Context):
         guild_id = ctx.guild.id
         decisions = await get_ai_decisions(guild_id, limit=50)
+        decisions = [d for d in decisions if d.get("guild_id") == guild_id]
         if not decisions:
             await ctx.reply("No AI decisions have been recorded yet.", ephemeral=True)
             return

--- a/database/operations.py
+++ b/database/operations.py
@@ -815,7 +815,7 @@ async def get_ai_decisions(
     try:
         results = await execute_query(
             """
-            SELECT id, message_id, author_id, author_name,
+            SELECT id, guild_id, message_id, author_id, author_name,
                    message_content_snippet, decision, decision_timestamp
             FROM ai_decisions
             WHERE guild_id = $1
@@ -833,6 +833,7 @@ async def get_ai_decisions(
             decision = json.loads(decision_json) if decision_json else {}
             normalized.append(
                 {
+                    "guild_id": row["guild_id"],
                     "message_id": row["message_id"],
                     "author_id": row["author_id"],
                     "author_name": row["author_name"],


### PR DESCRIPTION
## Summary
- include guild_id when retrieving AI decisions
- ensure last_decisions only returns records for the current guild

## Testing
- `pylint --disable=all --enable=E,F cogs/core_ai_cog.py`
- `npm run build` in `website`
- `npm run test` in `dashboard/frontend`
- `npm run lint` in `dashboard/frontend`
- `npm run build` in `dashboard/frontend`
- `pytest`
- `pyright`


------
https://chatgpt.com/codex/tasks/task_e_687b43ef22c08323b3bc9c6d3741e49f