### PR TITLE
Add channel option for error notifications

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -23,3 +23,6 @@ Owners:
   ILIKEPANCAKES: 1141746562922459136
   SLIPSTREAM: 452666956353503252
   PCHAN: 1146391317295935570
+
+# Optional channel ID to send error notifications instead of DMing the user
+ERROR_NOTIFICATION_CHANNEL_ID: null


### PR DESCRIPTION
## Summary
- allow error notifications to be sent to a channel
- send exceptions through `send_error_dm` for unified behavior
- test channel-based error notifications

## Testing
- `npm run build` in `website/`
- `npm run test` in `dashboard/frontend`
- `npm run lint` in `dashboard/frontend`
- `npm run build` in `dashboard/frontend`
- `pytest`
- `pyright`


------
https://chatgpt.com/codex/tasks/task_e_687b57f094a483238d5f794c51637145