### PR TITLE
Add keyword-based AI moderation rules

### DIFF
--- a/cogs/aimod_helpers/config_manager.py
+++ b/cogs/aimod_helpers/config_manager.py
@@ -23,6 +23,8 @@ MOD_LOG_API_SECRET_ENV_VAR = "MOD_LOG_API_SECRET"
 # Channel-specific configuration keys
 CHANNEL_EXCLUSIONS_KEY = "AI_EXCLUDED_CHANNELS"
 CHANNEL_RULES_KEY = "AI_CHANNEL_RULES"
+ANALYSIS_MODE_KEY = "AI_ANALYSIS_MODE"
+KEYWORD_RULES_KEY = "AI_KEYWORD_RULES"
 
 # Legacy paths (kept for compatibility but not used)
 GUILD_CONFIG_DIR = os.path.join(os.getcwd(), "wdiscordbot-json-data")
@@ -234,6 +236,42 @@ async def remove_channel_rules(guild_id: int, channel_id: int) -> bool:
 async def get_all_channel_rules(guild_id: int) -> dict:
     """Get all channel-specific rules for a guild."""
     return await get_guild_config_async(guild_id, CHANNEL_RULES_KEY, {})
+
+
+async def get_analysis_mode(guild_id: int) -> str:
+    """Return the AI analysis mode for the guild (all or keywords)."""
+    return await get_guild_config_async(guild_id, ANALYSIS_MODE_KEY, "all")
+
+
+async def set_analysis_mode(guild_id: int, mode: str) -> bool:
+    """Set the AI analysis mode for the guild."""
+    return await set_guild_config(guild_id, ANALYSIS_MODE_KEY, mode)
+
+
+async def get_keyword_rules(guild_id: int) -> dict:
+    """Get keyword/regex rules for the guild."""
+    return await get_guild_config_async(guild_id, KEYWORD_RULES_KEY, {})
+
+
+async def set_keyword_rules(guild_id: int, rules: dict) -> bool:
+    """Replace all keyword rules for the guild."""
+    return await set_guild_config(guild_id, KEYWORD_RULES_KEY, rules)
+
+
+async def update_keyword_rule(guild_id: int, name: str, rule: dict) -> bool:
+    """Add or update a single keyword rule."""
+    rules = await get_keyword_rules(guild_id)
+    rules[name] = rule
+    return await set_keyword_rules(guild_id, rules)
+
+
+async def delete_keyword_rule(guild_id: int, name: str) -> bool:
+    """Delete a keyword rule by name."""
+    rules = await get_keyword_rules(guild_id)
+    if name in rules:
+        del rules[name]
+        return await set_keyword_rules(guild_id, rules)
+    return True
 
 
 async def t_async(guild_id: int, key: str) -> str:

--- a/dashboard/backend/app/crud.py
+++ b/dashboard/backend/app/crud.py
@@ -1179,8 +1179,28 @@ async def get_ai_settings(db: Session, guild_id: int) -> schemas.AISettings:
     """Get AI settings for a guild."""
     channel_exclusions = await get_channel_exclusions(db, guild_id)
     channel_rules = await get_channel_rules(db, guild_id)
+    result = await db.execute(
+        text(
+            "SELECT key, value FROM guild_config WHERE guild_id = :guild_id AND key IN ('AI_ANALYSIS_MODE', 'AI_KEYWORD_RULES')"
+        ),
+        {"guild_id": guild_id},
+    )
+    analysis_mode = "all"
+    keyword_rules = {}
+    for key, value in result.fetchall():
+        if key == "AI_ANALYSIS_MODE":
+            analysis_mode = value if isinstance(value, str) else "all"
+        elif key == "AI_KEYWORD_RULES":
+            try:
+                keyword_rules = json.loads(value) if isinstance(value, str) else value
+            except json.JSONDecodeError:
+                keyword_rules = {}
+
     return schemas.AISettings(
-        channel_exclusions=channel_exclusions, channel_rules=channel_rules
+        analysis_mode=analysis_mode,
+        keyword_rules=keyword_rules,
+        channel_exclusions=channel_exclusions,
+        channel_rules=channel_rules,
     )
 
 
@@ -1188,10 +1208,33 @@ async def update_ai_settings(
     db: Session, guild_id: int, settings: schemas.AISettingsUpdate
 ) -> schemas.AISettings:
     """Update AI settings for a guild."""
+    if settings.analysis_mode is not None:
+        await db.execute(
+            text(
+                """
+                INSERT INTO guild_config (guild_id, key, value)
+                VALUES (:guild_id, 'AI_ANALYSIS_MODE', :value)
+                ON CONFLICT (guild_id, key) DO UPDATE SET value = :value, updated_at = CURRENT_TIMESTAMP
+                """
+            ),
+            {"guild_id": guild_id, "value": settings.analysis_mode},
+        )
+    if settings.keyword_rules is not None:
+        await db.execute(
+            text(
+                """
+                INSERT INTO guild_config (guild_id, key, value)
+                VALUES (:guild_id, 'AI_KEYWORD_RULES', :value)
+                ON CONFLICT (guild_id, key) DO UPDATE SET value = :value, updated_at = CURRENT_TIMESTAMP
+                """
+            ),
+            {"guild_id": guild_id, "value": json.dumps(settings.keyword_rules)},
+        )
     if settings.channel_exclusions:
         await update_channel_exclusions(db, guild_id, settings.channel_exclusions)
     if settings.channel_rules:
         await update_channel_rules(db, guild_id, settings.channel_rules)
+    await db.commit()
     return await get_ai_settings(db, guild_id)
 
 

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -357,6 +357,11 @@ class SecuritySettingsUpdate(BaseModel):
 
 
 class AISettings(BaseModel):
+    analysis_mode: str = Field("all", description="Analysis mode for AI")
+    keyword_rules: Dict[str, Dict[str, Any]] = Field(
+        default_factory=dict,
+        description="Keyword or regex based rules with instructions",
+    )
     channel_exclusions: ChannelExclusionSettings
     channel_rules: ChannelRulesUpdate
 
@@ -364,6 +369,8 @@ class AISettings(BaseModel):
 
 
 class AISettingsUpdate(BaseModel):
+    analysis_mode: Optional[str] = None
+    keyword_rules: Optional[Dict[str, Dict[str, Any]]] = None
     channel_exclusions: Optional[ChannelExclusionSettings] = None
     channel_rules: Optional[ChannelRulesUpdate] = None
 

--- a/dashboard/backend/tests/test_api.py
+++ b/dashboard/backend/tests/test_api.py
@@ -341,6 +341,8 @@ def test_get_ai_settings(async_client: TestClient, monkeypatch):
         return {
             "channel_exclusions": {"excluded_channels": ["123"]},
             "channel_rules": {"channel_rules": {"456": "Be nice"}},
+            "analysis_mode": "all",
+            "keyword_rules": {},
         }
 
     monkeypatch.setattr(
@@ -351,6 +353,7 @@ def test_get_ai_settings(async_client: TestClient, monkeypatch):
     assert response.status_code == 200
     settings = response.json()
     assert settings["channel_exclusions"]["excluded_channels"] == ["123"]
+    assert settings["analysis_mode"] == "all"
 
 
 def test_get_channels_settings(async_client: TestClient, monkeypatch):
@@ -524,6 +527,8 @@ def test_update_ai_settings(async_client: TestClient, monkeypatch):
                 "excluded_channels": settings.channel_exclusions.excluded_channels
             },
             "channel_rules": {"channel_rules": settings.channel_rules.channel_rules},
+            "analysis_mode": settings.analysis_mode or "all",
+            "keyword_rules": settings.keyword_rules or {},
         }
 
     monkeypatch.setattr(
@@ -533,11 +538,17 @@ def test_update_ai_settings(async_client: TestClient, monkeypatch):
     update_data = {
         "channel_exclusions": {"excluded_channels": ["456"]},
         "channel_rules": {"channel_rules": {"789": "No spam"}},
+        "analysis_mode": "keywords",
+        "keyword_rules": {
+            "r1": {"keywords": ["test"], "regex": [], "instructions": "hi"}
+        },
     }
     response = async_client.put("/api/guilds/123/config/ai", json=update_data)
     assert response.status_code == 200
     settings = response.json()
     assert settings["channel_exclusions"]["excluded_channels"] == ["456"]
+    assert settings["analysis_mode"] == "keywords"
+    assert "r1" in settings["keyword_rules"]
 
 
 def test_update_channels_settings(async_client: TestClient, monkeypatch):

--- a/dashboard/frontend/src/components/AISettings.jsx
+++ b/dashboard/frontend/src/components/AISettings.jsx
@@ -216,6 +216,29 @@ const AISettings = ({ guildId }) => {
                 {isSyncing ? "Syncing..." : "Sync Rules from #rules Channel"}
               </Button>
             </div>
+            <div className="space-y-2">
+              <Label htmlFor="analysis_mode">Analysis Mode</Label>
+              <select
+                id="analysis_mode"
+                value={config.analysis_mode || "all"}
+                onChange={(e) => handleInputChange("analysis_mode", e.target.value)}
+                className="w-full border rounded p-2"
+              >
+                <option value="all">Analyze All Messages</option>
+                <option value="keywords">Keyword Rules Only</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="keyword_rules">Keyword Rules (JSON)</Label>
+              <Textarea
+                id="keyword_rules"
+                value={JSON.stringify(config.keyword_rules || {}, null, 2)}
+                onChange={(e) =>
+                  handleInputChange("keyword_rules", JSON.parse(e.target.value || '{}'))
+                }
+                className="resize-y"
+              />
+            </div>
           </>
         )}
         <div className="flex justify-end gap-2">

--- a/dashboard/frontend/src/components/AISettings.test.jsx
+++ b/dashboard/frontend/src/components/AISettings.test.jsx
@@ -15,6 +15,8 @@ const mockConfig = {
   ai_system_prompt: 'You are a helpful assistant.',
   bot_enabled: true,
   test_mode: false,
+  analysis_mode: 'all',
+  keyword_rules: {},
 };
 
 describe('AISettings', () => {


### PR DESCRIPTION
## Summary
- support keyword/regex rules for AI moderation
- allow switching between analyzing all messages or just keyword matches
- surface new settings via bot commands and dashboard
- store analysis mode and keyword rules in guild config
- update frontend to manage new settings

## Testing
- `pylint --disable=all --enable=E,F cogs/aimod_helpers/config_manager.py cogs/config_cog.py cogs/core_ai_cog.py dashboard/backend/app/schemas.py dashboard/backend/app/crud.py dashboard/backend/tests/test_api.py`
- `pyright`
- `pytest`
- `npm run test` within `dashboard/frontend`
- `npm run lint` within `dashboard/frontend`
- `npm run build` within `dashboard/frontend`
- `npm run build` within `website`


------
https://chatgpt.com/codex/tasks/task_e_687c29c3bfac8323b9a4ddb058efa95a