### PR TITLE
Add rule-based AI moderation

### DIFF
--- a/cogs/aimod_helpers/config_manager.py
+++ b/cogs/aimod_helpers/config_manager.py
@@ -23,6 +23,8 @@ MOD_LOG_API_SECRET_ENV_VAR = "MOD_LOG_API_SECRET"
 # Channel-specific configuration keys
 CHANNEL_EXCLUSIONS_KEY = "AI_EXCLUDED_CHANNELS"
 CHANNEL_RULES_KEY = "AI_CHANNEL_RULES"
+ANALYSIS_MODE_KEY = "AI_ANALYSIS_MODE"
+MESSAGE_RULES_KEY = "AI_KEYWORD_RULES"
 
 # Legacy paths (kept for compatibility but not used)
 GUILD_CONFIG_DIR = os.path.join(os.getcwd(), "wdiscordbot-json-data")
@@ -234,6 +236,26 @@ async def remove_channel_rules(guild_id: int, channel_id: int) -> bool:
 async def get_all_channel_rules(guild_id: int) -> dict:
     """Get all channel-specific rules for a guild."""
     return await get_guild_config_async(guild_id, CHANNEL_RULES_KEY, {})
+
+
+async def get_analysis_mode(guild_id: int) -> str:
+    """Get the AI analysis mode for a guild."""
+    return await get_guild_config_async(guild_id, ANALYSIS_MODE_KEY, "all")
+
+
+async def set_analysis_mode(guild_id: int, mode: str) -> bool:
+    """Set the AI analysis mode for a guild."""
+    return await set_guild_config(guild_id, ANALYSIS_MODE_KEY, mode)
+
+
+async def get_message_rules(guild_id: int) -> list:
+    """Retrieve keyword/regex-based message rules."""
+    return await get_guild_config_async(guild_id, MESSAGE_RULES_KEY, [])
+
+
+async def set_message_rules(guild_id: int, rules: list) -> bool:
+    """Set keyword/regex-based message rules."""
+    return await set_guild_config(guild_id, MESSAGE_RULES_KEY, rules)
 
 
 async def t_async(guild_id: int, key: str) -> str:

--- a/cogs/config_cog.py
+++ b/cogs/config_cog.py
@@ -553,6 +553,20 @@ class ConfigCog(commands.Cog, name="Configuration"):
             )
             return
 
+    @config.command(
+        name="set_rules",
+        description="Manually set the AI moderation rules for this guild.",
+    )
+    @app_commands.describe(rules="The rules text for AI moderation")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_rules(self, ctx: commands.Context, *, rules: str):
+        """Manually set server rules used for AI moderation."""
+        await set_guild_config(ctx.guild.id, "SERVER_RULES", rules)
+        response_func = (
+            ctx.interaction.response.send_message if ctx.interaction else ctx.send
+        )
+        await response_func("Server rules have been updated.", ephemeral=False)
+
 
 async def setup(bot: commands.Bot):
     """Loads the ConfigCog."""

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -359,6 +359,8 @@ class SecuritySettingsUpdate(BaseModel):
 class AISettings(BaseModel):
     channel_exclusions: ChannelExclusionSettings
     channel_rules: ChannelRulesUpdate
+    analysis_mode: str
+    keyword_rules: List[Dict[str, Any]] = Field(default_factory=list)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -366,6 +368,8 @@ class AISettings(BaseModel):
 class AISettingsUpdate(BaseModel):
     channel_exclusions: Optional[ChannelExclusionSettings] = None
     channel_rules: Optional[ChannelRulesUpdate] = None
+    analysis_mode: Optional[str] = None
+    keyword_rules: Optional[List[Dict[str, Any]]] = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/dashboard/backend/tests/test_api.py
+++ b/dashboard/backend/tests/test_api.py
@@ -341,6 +341,8 @@ def test_get_ai_settings(async_client: TestClient, monkeypatch):
         return {
             "channel_exclusions": {"excluded_channels": ["123"]},
             "channel_rules": {"channel_rules": {"456": "Be nice"}},
+            "analysis_mode": "all",
+            "keyword_rules": [],
         }
 
     monkeypatch.setattr(
@@ -524,6 +526,8 @@ def test_update_ai_settings(async_client: TestClient, monkeypatch):
                 "excluded_channels": settings.channel_exclusions.excluded_channels
             },
             "channel_rules": {"channel_rules": settings.channel_rules.channel_rules},
+            "analysis_mode": settings.analysis_mode,
+            "keyword_rules": settings.keyword_rules,
         }
 
     monkeypatch.setattr(
@@ -533,6 +537,8 @@ def test_update_ai_settings(async_client: TestClient, monkeypatch):
     update_data = {
         "channel_exclusions": {"excluded_channels": ["456"]},
         "channel_rules": {"channel_rules": {"789": "No spam"}},
+        "analysis_mode": "all",
+        "keyword_rules": [],
     }
     response = async_client.put("/api/guilds/123/config/ai", json=update_data)
     assert response.status_code == 200

--- a/dashboard/frontend/src/components/AISettings.test.jsx
+++ b/dashboard/frontend/src/components/AISettings.test.jsx
@@ -13,6 +13,8 @@ const mockConfig = {
   ai_model: 'gpt-4-turbo',
   ai_temperature: 0.7,
   ai_system_prompt: 'You are a helpful assistant.',
+  analysis_mode: 'all',
+  keyword_rules: [],
   bot_enabled: true,
   test_mode: false,
 };
@@ -69,6 +71,18 @@ describe('AISettings', () => {
     const testModeSwitch = screen.getByLabelText(/AI Test Mode/i);
     fireEvent.click(testModeSwitch);
     expect(testModeSwitch).toBeChecked();
+  });
+
+  it('allows adding a keyword rule', async () => {
+    render(<AISettings guildId="123" />);
+    await waitFor(() => screen.getByText(/Add Rule/i));
+
+    const addButton = screen.getByText(/Add Rule/i);
+    fireEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Remove Rule/i).length).toBe(1);
+    });
   });
 
   it('saves settings and shows success toast', async () => {


### PR DESCRIPTION
## Summary
- support new AI settings for regex/keyword rules and analysis mode
- update config commands to allow manually setting server rules
- adapt AI logic to use new rules when deciding to analyze messages
- extend API CRUD/schemas to expose analysis mode and message rules
- add dashboard UI for setting analysis mode and keyword rules
- improve dashboard UI to add rules without JSON editing

## Testing
- `pytest -q`
- `pyright`
- `npm run build` in `website/`
- `npm run test` in `dashboard/frontend`
- `npm run lint` in `dashboard/frontend`
- `npm run build` in `dashboard/frontend`


------
https://chatgpt.com/codex/tasks/task_e_687c29c3bfac8323b9a4ddb058efa95a