### PR TITLE
Add website tests and lint setup

### DIFF
--- a/website/eslint.config.js
+++ b/website/eslint.config.js
@@ -1,0 +1,56 @@
+import js from '@eslint/js'
+import tseslint from 'typescript-eslint'
+import astro from 'eslint-plugin-astro'
+import reactHooks from 'eslint-plugin-react-hooks'
+import { defineConfig, globalIgnores } from 'eslint/config'
+
+export default defineConfig([
+  globalIgnores(['dist', 'build']),
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+    },
+  },
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    plugins: { '@typescript-eslint': tseslint.plugin, 'react-hooks': reactHooks },
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+    },
+  },
+  {
+    files: ['**/*.astro'],
+    plugins: { astro },
+    languageOptions: { parser: astro.parser },
+    rules: {
+      ...astro.configs.recommended.rules,
+    },
+  },
+  {
+    files: ['**/*.test.*'],
+    languageOptions: {
+      globals: {
+        vi: true,
+        describe: true,
+        it: true,
+        expect: true,
+      },
+    },
+  },
+])

--- a/website/package.json
+++ b/website/package.json
@@ -6,9 +6,12 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "vitest run",
+    "lint": "eslint ."
   },
   "dependencies": {
+    "@astrojs/cloudflare": "^12.6.0",
     "@astrojs/mdx": "^4.3.0",
     "@astrojs/react": "^4.3.0",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -28,10 +31,24 @@
     "react-dom": "^19.1.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.11",
-    "tailwindcss-animate": "^1.0.7",
-    "@astrojs/cloudflare": "^12.6.0"
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
-    "tw-animate-css": "^1.3.5"
+    "@eslint/js": "^9.31.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@types/jsdom": "^21.1.7",
+    "@typescript-eslint/eslint-plugin": "^8.37.0",
+    "@typescript-eslint/parser": "^8.37.0",
+    "@vitejs/plugin-react": "^4.7.0",
+    "eslint": "^9.31.0",
+    "eslint-plugin-astro": "^1.3.1",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "jsdom": "^26.1.0",
+    "tw-animate-css": "^1.3.5",
+    "typescript": "^5.8.3",
+    "typescript-eslint": "^8.37.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/website/src/components/blog/BlogIndex.test.tsx
+++ b/website/src/components/blog/BlogIndex.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import BlogIndex from './BlogIndex'
+
+const posts = [
+  { slug: 'a', title: 'A', excerpt: 'a' },
+  { slug: 'b', title: 'B', excerpt: 'b' },
+]
+
+global.fetch = vi.fn(() =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve({ posts }) })
+) as any
+
+
+describe('BlogIndex', () => {
+  it('renders posts from API', async () => {
+    render(<BlogIndex />)
+    await waitFor(() => {
+      expect(screen.getByText('A')).toBeInTheDocument()
+      expect(screen.getByText('B')).toBeInTheDocument()
+    })
+  })
+})

--- a/website/src/components/blog/BlogPost.test.tsx
+++ b/website/src/components/blog/BlogPost.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import BlogPost from './BlogPost'
+
+const post = {
+  title: 'Hello',
+  content: '<p>content</p>',
+  created_at: '2020-01-01T00:00:00Z',
+}
+
+global.fetch = vi.fn(() =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve(post) })
+) as any
+
+
+describe('BlogPost', () => {
+  it('renders post', async () => {
+    render(<BlogPost slug="hello" />)
+    await waitFor(() => {
+      expect(screen.getByText('Hello')).toBeInTheDocument()
+      expect(screen.getByText('content')).toBeInTheDocument()
+    })
+  })
+})

--- a/website/src/lib/utils.test.ts
+++ b/website/src/lib/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from './utils'
+
+describe('cn', () => {
+  it('merges class names', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar')
+  })
+
+  it('handles falsy values', () => {
+    expect(cn('foo', null as any, undefined, false, 'bar')).toBe('foo bar')
+  })
+})

--- a/website/vitest.config.ts
+++ b/website/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+})


### PR DESCRIPTION
## Summary
- add vitest + react testing libs and eslint config to website
- configure scripts for testing and linting
- create initial unit tests for blog components and utility

## Testing
- `yarn workspaces foreach -pt --all run test` *(fails: cannot find jsdom, vitest config issues)*
- `yarn workspaces foreach -pt --all run lint` *(fails: eslint config errors)*
- `yarn workspaces foreach -pt --all run build` *(fails: build error)*
- `pytest`
- `pyright`


------
https://chatgpt.com/codex/tasks/task_e_687c4c9dd714832392c46dbddf7e5b31