### PR TITLE
Fix undefined state for Admin health check

### DIFF
--- a/dashboard/frontend/src/components/AdminRawDBPage.jsx
+++ b/dashboard/frontend/src/components/AdminRawDBPage.jsx
@@ -40,6 +40,7 @@ const AdminRawDBPage = () => {
   const [editingRow, setEditingRow] = useState(null);
   const [deletingRow, setDeletingRow] = useState(null);
   const [pkColumns, setPkColumns] = useState([]);
+  const [healthStatus, setHealthStatus] = useState(null);
 
   useEffect(() => {
     const fetchTables = async () => {


### PR DESCRIPTION
## Summary
- add `healthStatus` state in `AdminRawDBPage`

## Testing
- `yarn lint` *(fails: astro files parse errors)*
- `yarn build`
- `yarn test` *(fails: blog tests use invalid matcher)*
- `pytest`
- `pyright`
- `pylint --disable=all --enable=E,F`

------
https://chatgpt.com/codex/tasks/task_e_687d3b9889b08323928f15211336603e