### PR TITLE
Add configurable dashboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ pip install -r requirements.txt
    cp config.example.yaml config.yaml
    ```
 2. Edit `config.yaml` to add your Discord bot token and server-specific settings.
+   - Set `Dashboard.ENABLED` to `true` and provide a `URL` if you want to enable the dashboard interface.
+   - Set `Dashboard.COMMAND_ENABLED` to `true` to load a command that links users to the dashboard.
+   - Set `LOAD_CONFIG_COG` to `false` if you do not want the configuration commands loaded.
 
 ### Running the Bot
 

--- a/bot.py
+++ b/bot.py
@@ -152,6 +152,11 @@ async def load_cogs():
         "aimod",  # Deprecated, functionality split into other cogs
         "ban_appeal_cog",  # Obsolete, functionality replaced by appeal_cog
     }
+    if not getattr(config, "LOAD_CONFIG_COG", True):
+        cogs_to_exclude.add("config_cog")
+    dashboard_cfg = getattr(config, "Dashboard", None)
+    if not (dashboard_cfg and getattr(dashboard_cfg, "COMMAND_ENABLED", False)):
+        cogs_to_exclude.add("dashboard_link_cog")
     for filename in os.listdir("cogs"):
         if filename.endswith(".py"):
             cog_name = filename[:-3]

--- a/cogs/captcha_cog.py
+++ b/cogs/captcha_cog.py
@@ -237,7 +237,7 @@ class CaptchaCog(commands.Cog):
                         continue
 
                     try:
-                        message = await channel.fetch_message(message_id)
+                        await channel.fetch_message(message_id)
                         # Create and add the persistent view
                         view = VerificationStartView(self)
                         self.bot.add_view(view, message_id=message_id)

--- a/cogs/dashboard_link_cog.py
+++ b/cogs/dashboard_link_cog.py
@@ -1,0 +1,32 @@
+import discord
+from discord.ext import commands
+
+from lists import config
+
+
+class DashboardLinkCog(commands.Cog):
+    """Provides a command to link the dashboard."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.url = getattr(getattr(config, "Dashboard", None), "URL", None)
+
+    @commands.hybrid_command(name="dashboard", description="Get the dashboard link")
+    async def dashboard(self, ctx: commands.Context):
+        """Send a button linking to the dashboard."""
+        if not self.url:
+            await ctx.send("Dashboard URL is not configured.", ephemeral=True if ctx.interaction else False)
+            return
+        view = discord.ui.View()
+        view.add_item(discord.ui.Button(label="Open Dashboard", url=self.url))
+        if ctx.interaction:
+            await ctx.interaction.response.send_message(
+                "Use the button below to access the dashboard.", view=view, ephemeral=True
+            )
+        else:
+            await ctx.send("Use the button below to access the dashboard.", view=view)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(DashboardLinkCog(bot))
+    print("DashboardLinkCog has been loaded.")

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -26,3 +26,12 @@ Owners:
 
 # Optional channel ID to send error notifications instead of DMing the user
 ERROR_NOTIFICATION_CHANNEL_ID: 1396224455876939786
+
+# Control whether the optional dashboard is enabled
+Dashboard:
+  ENABLED: false
+  URL: "http://localhost:3000"
+  COMMAND_ENABLED: false
+
+# Toggle loading of the ConfigCog
+LOAD_CONFIG_COG: true


### PR DESCRIPTION
## Summary
- add dashboard config options and ability to disable ConfigCog
- create DashboardLinkCog with a `/dashboard` command
- skip loading ConfigCog and DashboardLinkCog when disabled
- document new options in README
- test cog loading logic for new config flags

## Testing
- `ruff format cogs/dashboard_link_cog.py bot.py tests/test_bot.py`
- `ruff check cogs/dashboard_link_cog.py bot.py tests/test_bot.py`
- `pyright`
- `pytest`
- `./ci.sh` *(fails: The lockfile would have been modified by this install, which is explicitly forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6881201d10688323bd53a132b329a62c